### PR TITLE
fix: implement NewKeyPair

### DIFF
--- a/tls/provider.go
+++ b/tls/provider.go
@@ -81,7 +81,7 @@ func (p *certificateProvider) update() (ca []byte, cert tls.Certificate, err err
 		identity *talosx509.PEMEncodedCertificateAndKey
 	)
 
-	csr, identity, err = talosx509.NewCSRAndIdentity(p.dnsNames, p.ips)
+	csr, identity, err = talosx509.NewEd25519CSRAndIdentity(p.dnsNames, p.ips)
 	if err != nil {
 		return nil, cert, err
 	}

--- a/x509/x509_test.go
+++ b/x509/x509_test.go
@@ -2,13 +2,62 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//nolint: scopelint
 package x509_test
 
-import "testing"
+import (
+	"testing"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/talos-systems/crypto/x509"
+)
+
+func TestNewKeyPair(t *testing.T) {
+	rsaCA, err := x509.NewSelfSignedCertificateAuthority(x509.RSA(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ed25519ca, err := x509.NewSelfSignedCertificateAuthority(x509.RSA(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type args struct {
+		ca      *x509.CertificateAuthority
+		setters []x509.Option
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid RSA",
+			args: args{
+				ca:      rsaCA,
+				setters: []x509.Option{x509.RSA(true)},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid Ed25519",
+			args: args{
+				ca:      ed25519ca,
+				setters: []x509.Option{x509.RSA(false)},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := x509.NewKeyPair(tt.args.ca, tt.args.setters...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewKeyPair() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+		})
+	}
 }


### PR DESCRIPTION
This function was completely broken. This implements it properly.

BREAKING CHANGE:

The NewCSRAndIdentity function has been removed in favor of explicit
NewRSACSRAndIdentity, and NewEd25519CSRAndIdentity functions. This aligns with
the existing pattern in this package. To resolve this breaking change, use
NewEd25519CSRAndIdentity instead of NewCSRAndIdentity.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
