### PR TITLE
feat: add 'PEMEncodedKey' which allows to transport keys in YAML

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/talos-systems/crypto
 
 go 1.14
+
+require (
+	github.com/stretchr/testify v1.7.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/x509/x509_test.go
+++ b/x509/x509_test.go
@@ -8,6 +8,10 @@ package x509_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
 	"github.com/talos-systems/crypto/x509"
 )
 
@@ -60,4 +64,50 @@ func TestNewKeyPair(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPEMEncodedKeyRSA(t *testing.T) {
+	key, err := x509.NewRSAKey()
+	require.NoError(t, err)
+
+	encoded := &x509.PEMEncodedKey{
+		Key: key.KeyPEM,
+	}
+
+	marshaled, err := yaml.Marshal(encoded)
+	require.NoError(t, err)
+
+	var decoded x509.PEMEncodedKey
+
+	require.NoError(t, yaml.Unmarshal(marshaled, &decoded))
+
+	decodedKey, err := decoded.GetRSAKey()
+	require.NoError(t, err)
+
+	assert.Equal(t, key.KeyPEM, decodedKey.KeyPEM)
+	assert.Equal(t, key.PublicKeyPEM, decodedKey.PublicKeyPEM)
+}
+
+func TestPEMEncodedKeyEd25519(t *testing.T) {
+	key, err := x509.NewEd25519Key()
+	require.NoError(t, err)
+
+	encoded := &x509.PEMEncodedKey{
+		Key: key.PrivateKeyPEM,
+	}
+
+	marshaled, err := yaml.Marshal(encoded)
+	require.NoError(t, err)
+
+	var decoded x509.PEMEncodedKey
+
+	require.NoError(t, yaml.Unmarshal(marshaled, &decoded))
+
+	decodedKey, err := decoded.GetEd25519Key()
+	require.NoError(t, err)
+
+	assert.Equal(t, key.PrivateKey, decodedKey.PrivateKey)
+	assert.Equal(t, key.PublicKey, decodedKey.PublicKey)
+	assert.Equal(t, key.PrivateKeyPEM, decodedKey.PrivateKeyPEM)
+	assert.Equal(t, key.PublicKeyPEM, decodedKey.PublicKeyPEM)
 }


### PR DESCRIPTION
Key can be restored back into *RSAKey, *Ed25519Key with public key
recovered for further handling.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>