### PR TITLE
feat: support for key/certificate types RSA, Ed25519, ECDSA 

### DIFF
--- a/x509/constants.go
+++ b/x509/constants.go
@@ -8,3 +8,16 @@ import "time"
 
 // DefaultCertificateValidityDuration is a default certificate lifetime.
 const DefaultCertificateValidityDuration = 24 * time.Hour
+
+// PEM Block Header Types.
+const (
+	PEMTypeRSAPrivate     = "RSA PRIVATE KEY"
+	PEMTypeRSAPublic      = "PUBLIC KEY"
+	PEMTypeECPrivate      = "EC PRIVATE KEY"
+	PEMTypeECPublic       = "EC PUBLIC KEY"
+	PEMTypeEd25519Private = "ED25519 PRIVATE KEY"
+	PEMTypeEd25519Public  = "ED25519 PUBLIC KEY"
+
+	PEMTypeCertificate        = "CERTIFICATE"
+	PEMTypeCertificateRequest = "CERTIFICATE REQUEST"
+)

--- a/x509/x509_test.go
+++ b/x509/x509_test.go
@@ -2,11 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//nolint: scopelint
+//nolint: scopelint,goconst
 package x509_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,7 +22,12 @@ func TestNewKeyPair(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ed25519ca, err := x509.NewSelfSignedCertificateAuthority(x509.RSA(false))
+	ed25519ca, err := x509.NewSelfSignedCertificateAuthority()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ecdsaCA, err := x509.NewSelfSignedCertificateAuthority(x509.ECDSA(true))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,16 +45,21 @@ func TestNewKeyPair(t *testing.T) {
 		{
 			name: "valid RSA",
 			args: args{
-				ca:      rsaCA,
-				setters: []x509.Option{x509.RSA(true)},
+				ca: rsaCA,
 			},
 			wantErr: false,
 		},
 		{
 			name: "valid Ed25519",
 			args: args{
-				ca:      ed25519ca,
-				setters: []x509.Option{x509.RSA(false)},
+				ca: ed25519ca,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid ECDSA",
+			args: args{
+				ca: ecdsaCA,
 			},
 			wantErr: false,
 		},
@@ -61,6 +72,125 @@ func TestNewKeyPair(t *testing.T) {
 				t.Errorf("NewKeyPair() error = %v, wantErr %v", err, tt.wantErr)
 
 				return
+			}
+		})
+	}
+}
+
+func TestNewKeyPairViaPEM(t *testing.T) {
+	tests := []struct {
+		name string
+		opt  x509.Option
+	}{
+		{
+			name: "valid RSA",
+			opt:  x509.RSA(true),
+		},
+		{
+			name: "valid Ed25519",
+			opt:  x509.RSA(false),
+		},
+		{
+			name: "valid ECDSA",
+			opt:  x509.ECDSA(true),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []x509.Option{
+				tt.opt,
+				x509.Organization("kubernetes"),
+				x509.NotAfter(time.Now().Add(87600 * time.Hour)),
+				x509.NotBefore(time.Now()),
+			}
+
+			ca, err := x509.NewSelfSignedCertificateAuthority(opts...)
+			require.NoError(t, err)
+
+			pemEncoded := &x509.PEMEncodedCertificateAndKey{
+				Crt: ca.CrtPEM,
+				Key: ca.KeyPEM,
+			}
+
+			ca, err = x509.NewCertificateAuthorityFromCertificateAndKey(pemEncoded)
+			require.NoError(t, err)
+
+			_, err = x509.NewKeyPair(ca)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNewKeyViaPEM(t *testing.T) {
+	tests := []struct {
+		name string
+		algo string
+	}{
+		{
+			name: "RSA",
+			algo: "rsa",
+		},
+		{
+			name: "Ed25519",
+			algo: "ed25519",
+		},
+		{
+			name: "ECDSA",
+			algo: "ecdsa",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var keyPEM *x509.PEMEncodedKey
+
+			switch tt.algo {
+			case "rsa":
+				key, err := x509.NewRSAKey()
+				require.NoError(t, err)
+
+				keyPEM = &x509.PEMEncodedKey{
+					Key: key.KeyPEM,
+				}
+			case "ed25519":
+				key, err := x509.NewEd25519Key()
+				require.NoError(t, err)
+
+				keyPEM = &x509.PEMEncodedKey{
+					Key: key.PrivateKeyPEM,
+				}
+			case "ecdsa":
+				key, err := x509.NewECDSAKey()
+				require.NoError(t, err)
+
+				keyPEM = &x509.PEMEncodedKey{
+					Key: key.KeyPEM,
+				}
+			}
+
+			switch tt.algo {
+			case "rsa":
+				_, err := keyPEM.GetRSAKey()
+				require.NoError(t, err)
+			case "ed25519":
+				_, err := keyPEM.GetEd25519Key()
+				require.NoError(t, err)
+			case "ecdsa":
+				_, err := keyPEM.GetECDSAKey()
+				require.NoError(t, err)
+			}
+
+			k, err := keyPEM.GetKey()
+			require.NoError(t, err)
+
+			switch tt.algo {
+			case "rsa":
+				assert.IsType(t, &x509.RSAKey{}, k)
+			case "ed25519":
+				assert.IsType(t, &x509.Ed25519Key{}, k)
+			case "ecdsa":
+				assert.IsType(t, &x509.ECDSAKey{}, k)
 			}
 		})
 	}
@@ -109,5 +239,27 @@ func TestPEMEncodedKeyEd25519(t *testing.T) {
 	assert.Equal(t, key.PrivateKey, decodedKey.PrivateKey)
 	assert.Equal(t, key.PublicKey, decodedKey.PublicKey)
 	assert.Equal(t, key.PrivateKeyPEM, decodedKey.PrivateKeyPEM)
+	assert.Equal(t, key.PublicKeyPEM, decodedKey.PublicKeyPEM)
+}
+
+func TestPEMEncodedKeyECDSA(t *testing.T) {
+	key, err := x509.NewECDSAKey()
+	require.NoError(t, err)
+
+	encoded := &x509.PEMEncodedKey{
+		Key: key.KeyPEM,
+	}
+
+	marshaled, err := yaml.Marshal(encoded)
+	require.NoError(t, err)
+
+	var decoded x509.PEMEncodedKey
+
+	require.NoError(t, yaml.Unmarshal(marshaled, &decoded))
+
+	decodedKey, err := decoded.GetECDSAKey()
+	require.NoError(t, err)
+
+	assert.Equal(t, key.KeyPEM, decodedKey.KeyPEM)
 	assert.Equal(t, key.PublicKeyPEM, decodedKey.PublicKeyPEM)
 }


### PR DESCRIPTION
This also automatically derives key type and certificate signature
algorithm when possible. Option to select signature algorithm and key
type should only be passed usually when generating new CA or key.

Key/cert types:

* default - Ed25519
* `x509.RSA(true)` - RSA
* `x509.ECDSA(true)` - ECDSA

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>