### PR TITLE
fix: add back support for generating ECDSA keys with P-256 and SHA512

### DIFF
--- a/x509/x509.go
+++ b/x509/x509.go
@@ -192,6 +192,19 @@ func ECDSA(o bool) Option {
 	}
 }
 
+// ECDSASHA512 sets a flag for indicating that the requested operation should be
+// performed under the context of ECDSA with SHA512 instead of the default Ed25519.
+//
+// Note: this is only used for compatibility with previous version of the library,
+// new code should always use ECDSA(true).
+func ECDSASHA512(o bool) Option {
+	return func(opts *Options) {
+		if o {
+			opts.SignatureAlgorithm = x509.ECDSAWithSHA512
+		}
+	}
+}
+
 // NotAfter sets the validity bound describing when a certificate expires.
 func NotAfter(o time.Time) Option {
 	return func(opts *Options) {
@@ -1183,20 +1196,7 @@ func RSACertificateAuthority(template *x509.Certificate, opts *Options) (*Certif
 
 // ECDSACertificateAuthority creates an ECDSA CA.
 func ECDSACertificateAuthority(template *x509.Certificate) (*CertificateAuthority, error) {
-	var curve elliptic.Curve
-
-	switch template.SignatureAlgorithm { //nolint:exhaustive
-	case x509.ECDSAWithSHA256:
-		curve = elliptic.P256()
-	case x509.ECDSAWithSHA384:
-		curve = elliptic.P384()
-	case x509.ECDSAWithSHA512:
-		curve = elliptic.P521()
-	default:
-		return nil, fmt.Errorf("unsupported signature algorithm: %s", template.SignatureAlgorithm)
-	}
-
-	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}

--- a/x509/x509_test.go
+++ b/x509/x509_test.go
@@ -5,6 +5,7 @@
 package x509_test
 
 import (
+	stdx509 "crypto/x509"
 	"testing"
 	"time"
 
@@ -85,20 +86,29 @@ func TestNewKeyPairViaPEM(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct { //nolint:govet
-		name string
-		opt  x509.Option
+		name            string
+		opt             x509.Option
+		expectedSigAlgo stdx509.SignatureAlgorithm
 	}{
 		{
-			name: "valid RSA",
-			opt:  x509.RSA(true),
+			name:            "valid RSA",
+			opt:             x509.RSA(true),
+			expectedSigAlgo: stdx509.SHA512WithRSA,
 		},
 		{
-			name: "valid Ed25519",
-			opt:  x509.RSA(false),
+			name:            "valid Ed25519",
+			opt:             x509.RSA(false),
+			expectedSigAlgo: stdx509.PureEd25519,
 		},
 		{
-			name: "valid ECDSA",
-			opt:  x509.ECDSA(true),
+			name:            "valid ECDSA",
+			opt:             x509.ECDSA(true),
+			expectedSigAlgo: stdx509.ECDSAWithSHA256,
+		},
+		{
+			name:            "valid ECDSA with SHA512",
+			opt:             x509.ECDSASHA512(true),
+			expectedSigAlgo: stdx509.ECDSAWithSHA512,
 		},
 	}
 
@@ -116,6 +126,8 @@ func TestNewKeyPairViaPEM(t *testing.T) {
 
 			ca, err := x509.NewSelfSignedCertificateAuthority(opts...)
 			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedSigAlgo, ca.Crt.SignatureAlgorithm)
 
 			pemEncoded := &x509.PEMEncodedCertificateAndKey{
 				Crt: ca.CrtPEM,


### PR DESCRIPTION
This is required to support config generation for older versions of
Talos.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>