### PR TITLE
chore: add json tags

### DIFF
--- a/x509/x509.go
+++ b/x509/x509.go
@@ -86,13 +86,13 @@ type KeyPair struct {
 // PEMEncodedCertificateAndKey represents a PEM encoded certificate and
 // private key pair.
 type PEMEncodedCertificateAndKey struct {
-	Crt []byte
-	Key []byte
+	Crt []byte `json:"Crt"`
+	Key []byte `json:"Key"`
 }
 
 // PEMEncodedKey represents a PEM encoded private key.
 type PEMEncodedKey struct {
-	Key []byte
+	Key []byte `json:"Key"`
 }
 
 // Options is the functional options struct.


### PR DESCRIPTION
Add JSON tags so that the fields can be un-marshelled by tools like
Pulumi when creating a pulumi provider for Talos SecretsBundle,
ref: https://github.com/frezbo/pulumi-provider-talos/blob/main/provider/cmd/pulumi-resource-talos/schema.json

Signed-off-by: Noel Georgi <git@frezbo.dev>